### PR TITLE
Add test-unit gem depenency

### DIFF
--- a/fluent-plugin-eventcounter.gemspec
+++ b/fluent-plugin-eventcounter.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
 end

--- a/fluent-plugin-eventcounter.gemspec
+++ b/fluent-plugin-eventcounter.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "test-unit", ">= 3.1.0"
+  gem.add_development_dependency "test-unit", "~> 3.1.0"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible
layer.

It should add this dependency to develop this plugin with Ruby 2.2 series.
