### PR TITLE
Support secret parameter feature

### DIFF
--- a/lib/fluent/plugin/out_eventcounter.rb
+++ b/lib/fluent/plugin/out_eventcounter.rb
@@ -10,7 +10,7 @@ class Fluent::EventCounterOutput < Fluent::BufferedOutput
 
   config_param :redis_host, :string, :default => 'localhost'
   config_param :redis_port, :integer, :default => 6379
-  config_param :redis_password, :string, :default => nil
+  config_param :redis_password, :string, :default => nil, :secret => true
   config_param :redis_db_number, :integer, :default => 0
   config_param :redis_output_key, :string, :default => ''
 


### PR DESCRIPTION
`redis_password` contains sensitive information.
This parameter should be concealed with secret parameter feature.
